### PR TITLE
Allow Freezer to override object methods

### DIFF
--- a/lib/deep_freezer/base.rb
+++ b/lib/deep_freezer/base.rb
@@ -19,7 +19,11 @@ class DeepFreezer::Base
   def freeze
     freezable = @obj.class.new
     self.class.attrs.each do |attr|
-      freezable.send("#{attr}=", @obj.send(attr))
+      if self.respond_to?(attr)
+        freezable.send("#{attr}=", self.send(attr))
+      else
+        freezable.send("#{attr}=", @obj.send(attr))
+      end
     end
 
     yaml = ({ "#{freezable.class.to_s.tableize}_#{freezable.id.to_s}" => freezable.attributes }.to_yaml).gsub("---", "")


### PR DESCRIPTION
Extend the `freeze` method in `DeepFreezer::Base` to first check whether the Freezer overrides a method from the object being frozen. For example, when freezing a `User` entity you could specify an `email` method in the `UserFreezer` and obfuscate/replace the email address.